### PR TITLE
Update AuthenticationStateExtensions.cs

### DIFF
--- a/MyApp/AuthenticationStateExtensions.cs
+++ b/MyApp/AuthenticationStateExtensions.cs
@@ -7,9 +7,10 @@ namespace MyApp {
     public static class AuthenticationStateExtensions {
         public static JsonServiceClient ToClient(this AuthenticationState state){
             var navigationManager = HostContext.Container.Resolve<NavigationManager>();
-            var baseUri = navigationManager.BaseUri;var apiKey = state.User.Claims.Where(c => c.Type == "ApiKey").FirstOrDefault();
-            var client = new JsonServiceClient(navigationManager.BaseUri);
-            client.BearerToken = apiKey?.Value;
+            var baseUri = navigationManager.BaseUri;
+            var sessionId = state.User.Claims.Where(c => c.Type == "SessionId").FirstOrDefault();
+            var client = new JsonServiceClient(baseUri);
+            client.Headers["X-ss-id"] = sessionId.Value;
             return client;
         }
     }


### PR DESCRIPTION
_Code change to show a possible alternative approach, not a real pull request_

Hi, instead of using ApiKeys did you try capturing the SessionId as a claim then passing it by-header when calling the API? It seems to work as well for me.

However even without this change I was getting System.InvalidOperationException: ''RemoteNavigationManager' has not been initialized.' here `navigationManager.BaseUri;`. The base URI could just be put in a config setting I guess.

Thanks for this project, it's given me a few ideas for my apps.